### PR TITLE
🐛 Fix: Add missing properties to Quiz interface

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,4 +37,14 @@ export interface Quiz {
   questions: Question[];
   created_at?: string;
   user_id?: string; // ユーザーID（認証済みまたは匿名）を追加
+  
+  // 以下、アプリケーション内で使用される追加プロパティ
+  user_answers?: Record<number, string>; // ユーザーの回答データ
+  score?: {
+    correct?: number;     // 正解数
+    total?: number;       // 総問題数
+    percentage?: number;  // 正答率
+  };
+  last_saved?: string;   // 最終保存日時
+  last_played?: string;  // 最終プレイ日時
 }


### PR DESCRIPTION
## 🔍 Issue Analysis

TypeScript build error during Vercel deployment:
```
Type error: Property 'user_answers' does not exist on type 'Quiz'.
```

## 🛠️ Changes Made

Added the following missing properties to the `Quiz` interface in `lib/types.ts`:
- `user_answers`: Record of user's selected answers
- `score`: Object containing score information (correct, total, percentage)
- `last_saved`: Timestamp of when the quiz was last saved
- `last_played`: Timestamp of when the quiz was last played

## 📊 Expected Outcome

- ✅ TypeScript compiler will recognize all properties being used
- ✅ Build errors will be resolved
- ✅ Application will deploy successfully to Vercel

## 🧪 Testing

The changes have been tested to ensure:
1. Type definitions match actual usage in the codebase
2. No regression in functionality
3. Build process completes successfully
